### PR TITLE
Disambiguate parsing "Aug 12" and "12 Aug", tag "Hinted Months", Also fix ordinal suffixes for 21-23 and 31.

### DIFF
--- a/src/ec_date.erl
+++ b/src/ec_date.erl
@@ -189,6 +189,21 @@ parse([Hour,$:,Min | PAM], {Date, _Time}, _Opts) when ?is_meridian(PAM) ->
 parse([Hour | PAM],{Date,_Time}, _Opts) when ?is_meridian(PAM) ->
     {Date, {hour(Hour,PAM), 0, 0}};
 
+%% Dates (Any combination with word month "aug 8th, 2008", "8 aug 2008", "2008 aug 21" "2008 5 aug" )
+%% Will work because of the "Hinted month"
+parse([Day,Month,Year], {_Date, Time}, _Opts)
+  when ?is_day(Day) andalso ?is_hinted_month(Month) andalso ?is_year(Year) ->
+    {{Year, Month, Day}, Time};
+parse([Month,Day,Year], {_Date, Time}, _Opts)
+  when ?is_day(Day) andalso ?is_hinted_month(Month) andalso ?is_year(Year) ->
+    {{Year, Month, Day}, Time};
+parse([Year,Day,Month], {_Date, Time}, _Opts)
+  when ?is_day(Day) andalso ?is_hinted_month(Month) andalso ?is_year(Year) ->
+    {{Year, Month, Day}, Time};
+parse([Year,Month,Day], {_Date, Time}, _Opts)
+  when ?is_day(Day) andalso ?is_hinted_month(Month) andalso ?is_year(Year) ->
+    {{Year, Month, Day}, Time};
+
 %% Dates 23/april/1963
 parse([Day,Month,Year], {_Date, Time}, _Opts) ->
     {{Year, Month, Day}, Time};
@@ -654,6 +669,11 @@ ltoi(X) ->
 basic_format_test_() ->
     [
      ?_assertEqual(format("F j, Y, g:i a",?DATE), "March 10, 2001, 5:16 pm"),
+     ?_assertEqual(format("F jS, Y, g:i a",?DATE), "March 10th, 2001, 5:16 pm"),
+     ?_assertEqual(format("F jS",{{2011,3,21},{0,0,0}}), "March 21st"),
+     ?_assertEqual(format("F jS",{{2011,3,22},{0,0,0}}), "March 22nd"),
+     ?_assertEqual(format("F jS",{{2011,3,23},{0,0,0}}), "March 23rd"),
+     ?_assertEqual(format("F jS",{{2011,3,31},{0,0,0}}), "March 31st"),
      ?_assertEqual(format("m.d.y",?DATE), "03.10.01"),
      ?_assertEqual(format("j, n, Y",?DATE), "10, 3, 2001"),
      ?_assertEqual(format("Ymd",?DATE), "20010310"),
@@ -709,6 +729,50 @@ basic_parse_test_() ->
                    parse("August 22nd, 2008, 6:15:15pm", ?DATE)),
      ?_assertEqual({{2008,8,22}, {18,15,0}},
                    parse("Aug 22nd 2008, 18:15", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {17,16,17}},
+                   parse("2nd of August 2008", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {17,16,17}},
+                   parse("August 2nd, 2008", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {17,16,17}},
+                   parse("2nd  August, 2008", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {17,16,17}},
+                   parse("2008 August 2nd", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,0,0}},
+                   parse("2-Aug-2008 6 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("2-Aug-2008 6:35 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,12}},
+                   parse("2-Aug-2008 6:35:12 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,0,0}},
+                   parse("August/2/2008 6 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("August/2/2008 6:35 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("2 August 2008 6:35 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,0,0}},
+                   parse("2 Aug 2008 6AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("2 Aug 2008 6:35AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("2 Aug 2008 6:35 AM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,0,0}},
+                   parse("2 Aug 2008 6", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {6,35,0}},
+                   parse("2 Aug 2008 6:35", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,35,0}},
+                   parse("2 Aug 2008 6:35 PM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,0,0}},
+                   parse("2 Aug 2008 6 PM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,0,0}},
+                   parse("Aug 2, 2008 6 PM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,0,0}},
+                   parse("August 2nd, 2008 6:00 PM", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,15,15}},
+                   parse("August 2nd 2008, 6:15:15pm", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,15,15}},
+                   parse("August 2nd, 2008, 6:15:15pm", ?DATE)),
+     ?_assertEqual({{2008,8,2}, {18,15,0}},
+                   parse("Aug 2nd 2008, 18:15", ?DATE)),
      ?_assertEqual({{2012,12,10}, {0,0,0}},
                    parse("Dec 10th, 2012, 12:00 AM", ?DATE)),
      ?_assertEqual({{2012,12,10}, {0,0,0}},


### PR DESCRIPTION
I'm sorry for the pull request from out of the blue:

This started with just trying to parse the date format:

December 21st, 2013 7:00pm, which was failing with a bad_date error.

The solution involved setting up "Hinted Months", which was just a term
I used to indicate that a month was specified by name (ie "December"),
rather than by number (ie, "12"). Previously, named months were simply
replaced by their respective numbers in the parser.  This tags those
named months so that the parser will unambiguously parse them correctly.

A tagged "Hinted Month" is simply a tuple with the tag `?MONTH_TAG`. For
example: "December" gets converted to `{?MONTH_TAG, 12}`

For example: "Aug 12" and "12 Aug". It's clear to the _reader_ what is
meant, but when converted to simply 8 and 12, the parser has no way of
knowing which is which.

Doing this was aided with the addition of some macros to help it
along, since doing just straight comparisons with the hinted months was
yielding unexpected results. For example: `{mon, 1} > 31`  returns
true, so changing that comparison to an ?is_year/1 macro that does:
`is_integer(Y) andalso Y > 31`.

It might not be a bad idea to help the parser be _very_ unambiguous by
putting these macros on all comparisons.

Also, while I realize this should probably be a separate PR since it's a completely separate issue, this includes a simple fix fixing the ordinal suffixes for 21, 22, 23, and 31 (which previously all did "th")

Thanks. Please let me know if anything needs changing, or doesn't live up to some coding standards or expectations.

-Jesse
