### PR TITLE
Support Twitter-style timestamps

### DIFF
--- a/src/ec_semver_parser.erl
+++ b/src/ec_semver_parser.erl
@@ -17,7 +17,7 @@
 file(Filename) -> case file:read_file(Filename) of {ok,Bin} -> parse(Bin); Err -> Err end.
 
 -spec parse(binary() | list()) -> any().
-parse(List) when is_list(List) -> parse(list_to_binary(List));
+parse(List) when is_list(List) -> parse(unicode:characters_to_binary(List));
 parse(Input) when is_binary(Input) ->
   _ = setup_memo(),
   Result = case 'semver'(Input,{{line,1},{column,1}}) of


### PR DESCRIPTION
Twitter uses a non-standard format for their timestamps [1], which look like "Wed May 23 06:01:13 +0000 2007". I added support in ec_date to parse these timestamps including two tests. All previous tests pass as well.

References
[1] https://dev.twitter.com/rest/reference/get/statuses/user_timeline
