### PR TITLE
Introduce simple, preliminary TERM capability query.

### DIFF
--- a/src/ec_cmd_log.erl
+++ b/src/ec_cmd_log.erl
@@ -218,13 +218,9 @@ format(Log) ->
 
 -spec colorize(t(), color(), boolean(), string()) -> string().
 colorize(#state_t{caller=command_line}, Color, false, Msg) when is_integer(Color) ->
-    colorize_(Color, 0, Msg);
+    lists:flatten(io_lib:format("\033[~B;~Bm~s~s\033[0m", [0, Color, ?PREFIX, Msg]));
 colorize(_LogState, _Color, _Bold, Msg) ->
     Msg.
-
--spec colorize_(color(), integer(), string()) -> string().
-colorize_(Color, Bold, Msg) when is_integer(Color), is_integer(Bold)->
-    lists:flatten(io_lib:format("\033[~B;~Bm~s~s\033[0m", [Bold, Color, ?PREFIX, Msg])).
 
 %%%===================================================================
 %%% Test Functions

--- a/src/ec_cmd_log.erl
+++ b/src/ec_cmd_log.erl
@@ -50,7 +50,8 @@
 -define(PREFIX, "===> ").
 
 -record(state_t, {log_level=0 :: int_log_level(),
-                  caller=api :: caller()}).
+                  caller=api :: caller(),
+                  term_cap=full :: full | dumb }).
 
 %%============================================================================
 %% types
@@ -86,7 +87,7 @@ new(LogLevel) ->
 
 -spec new(log_level(), caller()) -> t().
 new(LogLevel, Caller) when LogLevel >= 0, LogLevel =< 3 ->
-    #state_t{log_level=LogLevel, caller=Caller};
+    #state_t{log_level=LogLevel, caller=Caller, term_cap=query_term_env()};
 new(AtomLogLevel, Caller)
   when AtomLogLevel =:= error;
        AtomLogLevel =:= warn;
@@ -217,10 +218,26 @@ format(Log) ->
      <<")">>].
 
 -spec colorize(t(), color(), boolean(), string()) -> string().
-colorize(#state_t{caller=command_line}, Color, false, Msg) when is_integer(Color) ->
+colorize(#state_t{caller=command_line, term_cap=full}, Color, false, Msg) when is_integer(Color) ->
     lists:flatten(io_lib:format("\033[~B;~Bm~s~s\033[0m", [0, Color, ?PREFIX, Msg]));
+colorize(#state_t{caller=command_line, term_cap=dumb}, Color, _Bold, Msg) when is_integer(Color) ->
+    lists:flatten(io_lib:format("~s~s", [?PREFIX, Msg]));
 colorize(_LogState, _Color, _Bold, Msg) ->
     Msg.
+
+%% @doc Query the term enviroment
+%% For reasons of simplicity, we don't parse terminal capabilities yet, although
+%% a later version could do so. Rather, we provide a simple match-list of terminal
+%% capabilities.
+%% @end
+-spec query_term_env() -> full | dumb.
+query_term_env() ->
+    term_capabilities(os:getenv("TERM")).
+
+-spec term_capabilities(string()) -> full | dumb.
+term_capabilities("xterm") -> full;
+term_capabilities("dumb") -> dumb;
+term_capabilities(_) -> full. %% Default to the backwards compatible version.
 
 %%%===================================================================
 %%% Test Functions


### PR DESCRIPTION
When erlware_commons logs to the command_line, it assumes the
environment has common modern capabilities and color display. In
general, this is not the case and then color codes are sent verbatim
to the terminal.

This patch introduces a new field in #state_t{}, term_cap, encoding
if the terminal runs with 'full' or 'dumb' capabilities. In the latter case,
color display is suppressed. Initialization of the #state_t{} record queries
the environment once for the TERM variable in order to figure out what
it supports. The default is 'full' capability to be fully backwards compatible.

While here, fold the colorize_ function into colorize/4, since it is too simple
to warrant having a function of its own, and only has a single call site.