### PR TITLE
Git v option

### DIFF
--- a/src/ec_git_vsn.erl
+++ b/src/ec_git_vsn.erl
@@ -24,7 +24,7 @@
 %%%===================================================================
 %% This should be opaque, but that kills dialyzer so for now we export it
 %% however you should not rely on the internal representation here
--type t() :: {string()}.
+-type t() :: {}.
 
 %%%===================================================================
 %%% API
@@ -32,7 +32,7 @@
 
 -spec new() -> t().
 new() ->
-    {"v"}.
+    {}.
 
 -spec vsn(t()) -> {ok, string()} | {error, Reason::any()}.
 vsn(Data) ->
@@ -85,15 +85,15 @@ get_patch_count(RawRef) ->
     os:cmd(Cmd).
 
 -spec parse_tags(t()) -> {string()|undefined, ec_semver:version_string()}.
-parse_tags({Prefix}) ->
-    first_valid_tag(os:cmd("git log --oneline --decorate  | grep -F \"tag: \""), Prefix).
+parse_tags(_) ->
+    first_valid_tag(os:cmd("git log --oneline --decorate  | grep -F \"tag: \"")).
     %% TODO: The following command sould be able to get the version
     %% number directly, without a re:run. Should be checked for POSIX
-    %% "git log --oneline --decorate | grep -F \"tag: \" --color=never | head -n 1 | sed  \"s/.*tag: " ++ Prefix ++ "\([^,)]*\).*/\1/\"".
+    %% "git log --oneline --decorate | grep -F \"tag: \" --color=never | head -n 1 | sed  \"s/.*tag: v?\([^,)]*\).*/\1/\"".
 
--spec first_valid_tag(string(), string()) -> {string()|undefined, ec_semver:version_string()}.
-first_valid_tag(Line, Prefix) ->
-    RE = lists:flatten(io_lib:format("(\\(|\\s)tag:\\s(~s([^,\\)]+))", [Prefix])),
+-spec first_valid_tag(string()) -> {string()|undefined, ec_semver:version_string()}.
+first_valid_tag(Line) ->
+    RE = "(\\(|\\s)tag:\\s(v?([^,\\)]+))",
     case re:run(Line, RE, [{capture, [2, 3], list}]) of
         {match,[Tag, Vsn]} ->
             {Tag, Vsn};

--- a/src/erlware_commons.app.src
+++ b/src/erlware_commons.app.src
@@ -1,13 +1,11 @@
-%% -*- mode: Erlang; fill-column: 75; comment-column: 50; -*-
-{application, erlware_commons,
- [{description, "Additional standard library for Erlang"},
-  {vsn, "0.15.0"},
-  {modules, []},
-  {registered, []},
-  {applications, [kernel, stdlib]},
-
-  {contributors,["Eric Merritt", "Tristan Sloughter",
-                 "Jordan Wilberding", "Martin Logan"]},
-  {licenses, ["Apache"]},
-  {links, [{"Github","https://github.com/erlware/erlware_commons"}]}
- ]}.
+{application,erlware_commons,
+             [{description,"Additional standard library for Erlang"},
+              {vsn,"0.16.0"},
+              {modules,[]},
+              {registered,[]},
+              {applications,[kernel,stdlib]},
+              {contributors,["Eric Merritt","Tristan Sloughter",
+                             "Jordan Wilberding","Martin Logan"]},
+              {licenses,["Apache"]},
+              {links,[{"Github",
+                       "https://github.com/erlware/erlware_commons"}]}]}.

--- a/test/ec_plists_tests.erl
+++ b/test/ec_plists_tests.erl
@@ -1,8 +1,6 @@
 %%% @copyright Erlware, LLC.
 -module(ec_plists_tests).
 
--ifdef(DEV_ONLY).
-
 -include_lib("eunit/include/eunit.hrl").
 
 %%%===================================================================
@@ -76,4 +74,3 @@ ftmap_bad_test() ->
     ?assertMatch([{value, 1}, {error,{throw,test_exception}}, {value, 3},
                   {value, 4}, {value, 5}] , Results).
 
--endif.


### PR DESCRIPTION
This makes the use of the prefix option to `ec_git_vsn` pointless by just making `v` as a prefix optional. And bumps to 0.16.0.

I need this in so I can finish up changes to rebar3 and its hex plugin so we no longer have to manually version bump but instead can go back to just using `git` as the version and have it replace that before publishing to hex.