### PR TITLE
fix DOWN messages from external sources issue

### DIFF
--- a/src/ec_plists.erl
+++ b/src/ec_plists.erl
@@ -772,8 +772,8 @@ receivefrom(Pid) ->
     receive
         {Pid, R} ->
             R;
-        {'DOWN', _, _, BadPid, Reason} when Reason =/= normal ->
-            erlang:throw({BadPid, Reason});
+        {'DOWN', _, _, Pid, Reason} when Reason =/= normal ->
+            erlang:throw({Pid, Reason});
         {timerrang, _} ->
             erlang:throw({nil, timeout})
     end.

--- a/test/ec_plists_tests.erl
+++ b/test/ec_plists_tests.erl
@@ -74,3 +74,11 @@ ftmap_bad_test() ->
     ?assertMatch([{value, 1}, {error,{throw,test_exception}}, {value, 3},
                   {value, 4}, {value, 5}] , Results).
 
+external_down_message_test() ->
+    erlang:spawn_monitor(fun() -> erlang:throw(fail) end),
+    Results = ec_plists:map(fun(_) ->
+                                    ok
+                            end,
+                            lists:seq(1, 5)),
+    ?assertMatch([ok, ok, ok, ok, ok],
+                 Results).


### PR DESCRIPTION
Simple fix that makes functions using local_runmany() insensitive for external DOWN messages.

After some considerations, I do not see much value in storing and matching on Ref from {Pid, _} = erlang:spawn_monitor(F) (https://github.com/erlware/erlware_commons/blob/master/src/ec_plists.erl#L755). Let me know if I am wrong.