### PR TITLE
Fix `rebar.config.script` to work with latest `rebar3`.

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,8 +1,7 @@
 IsRebar3 = case application:get_key(rebar, vsn) of
-               {ok, VSN} ->
-                   [VSN1 | _] = string:tokens(VSN, "-"),
-                   [Maj, Min, Patch] = string:tokens(VSN1, "."),
-                   (list_to_integer(Maj) >= 3);
+               {ok, Vsn} ->
+                   [MajorVersion|_] = string:tokens(Vsn, "."),
+                   (list_to_integer(MajorVersion) >= 3);
                undefined ->
                    false
            end,


### PR DESCRIPTION
Fix script so it can compile git-versioned rebar3 variables as that is the way these versions can look when updated using `rebar3 local upgrade`.

Fixes #101.