### PR TITLE
Use cf 0.2.2 with rebar2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -7,7 +7,7 @@ IsRebar3 = case application:get_key(rebar, vsn) of
            end,
 
 Rebar2Deps = [
-              {cf, ".*", {git, "https://github.com/project-fifo/cf", {tag, "0.2.0"}}}
+              {cf, ".*", {git, "https://github.com/project-fifo/cf", {tag, "0.2.2"}}}
              ],
 
 case IsRebar3 of


### PR DESCRIPTION
cf 0.2.0 doesn't compile with rebar2, but 0.2.2 (recently tagged) works and passes tests.
