### PR TITLE
Add compile-time switch for OTP-20 string funcs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,7 @@
   {platform_define, "^R1[4|5]", deprecated_crypto},
   {platform_define, "^1[8|9]", rand_module},
   {platform_define, "^2", rand_module},
+  {platform_define, "^2", unicode_str},
   debug_info,
   warnings_as_errors]}.
 

--- a/src/ec_date.erl
+++ b/src/ec_date.erl
@@ -101,7 +101,7 @@ parse(Date, Now) ->
     do_parse(Date, Now, []).
 
 do_parse(Date, Now, Opts) ->
-    case filter_hints(parse(tokenise(string:to_upper(Date), []), Now, Opts)) of
+    case filter_hints(parse(tokenise(uppercase(Date), []), Now, Opts)) of
         {error, bad_date} ->
             erlang:throw({?MODULE, {bad_date, Date}});
         {D1, T1} = {{Y, M, D}, {H, M1, S}}
@@ -727,6 +727,12 @@ pad6(X) when is_integer(X) ->
 
 ltoi(X) ->
     list_to_integer(X).
+
+-ifdef(unicode_str).
+uppercase(Str) -> string:uppercase(Str).
+-else.
+uppercase(Str) -> string:to_upper(Str).
+-endif.
 
 %%%===================================================================
 %%% Tests

--- a/src/ec_git_vsn.erl
+++ b/src/ec_git_vsn.erl
@@ -88,7 +88,16 @@ get_patch_count(RawRef) ->
 parse_tags(Pattern) ->
     Cmd = io_lib:format("git describe --abbrev=0 --match \"~s*\"", [Pattern]),
     Tag = os:cmd(Cmd),
-    Vsn = string:substr(Tag, string:len(Pattern) + 1),
-    Vsn1 = string:strip(Vsn, left, $v),
+    Vsn = slice(Tag, len(Pattern) + 1),
+    Vsn1 = trim(Vsn, left, $v),
     {Tag, Vsn1}.
 
+-ifdef(unicode_str).
+len(Str) -> string:length(Str).
+trim(Str, Dir, Chars) -> string:trim(Str, Dir, Chars).
+slice(Str, Len) -> string:slice(Str, Len).
+-else.
+len(Str) -> string:len(Str).
+trim(Str, Dir, Chars) -> string:strip(Str, Dir, Chars).
+slice(Str, Len) -> string:substr(Str, Len).
+-endif.

--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -127,7 +127,7 @@ ask_convert(Prompt, TransFun, Type,  Default) ->
                                                            Default ->
                                                                [" (", io_lib:format("~p", [Default]) , ")"]
                                                        end, "> "])),
-    Data = string:strip(string:strip(io:get_line(NewPrompt)), both, $\n),
+    Data = trim(trim(io:get_line(NewPrompt)), both, $\n),
     Ret = TransFun(Data),
     case Ret of
         no_data ->
@@ -196,6 +196,14 @@ get_string(String) ->
         false ->
             no_clue
     end.
+
+-ifdef(unicode_str).
+trim(Str) -> string:trim(Str).
+trim(Str, Dir, Chars) -> string:trim(Str, Dir, Chars).
+-else.
+trim(Str) -> string:strip(Str).
+trim(Str, Dir, Chars) -> string:strip(Str, Dir, Chars).
+-endif.
 
 %%%====================================================================
 %%% tests


### PR DESCRIPTION
Allows support for Unicode data, and prevents compile warnings that will
start with OTP-20.