### PR TITLE
Bump to 1.0.2

### DIFF
--- a/src/erlware_commons.app.src
+++ b/src/erlware_commons.app.src
@@ -1,6 +1,6 @@
 {application,erlware_commons,
              [{description,"Additional standard library for Erlang"},
-              {vsn,"1.0.1"},
+              {vsn,"1.0.2"},
               {modules,[]},
               {registered,[]},
               {applications,[kernel,stdlib,cf]},


### PR DESCRIPTION
This is just so that we can have the tag and hex version pointing to the same commit