### PR TITLE
Fix bad unicode transition for OTP 20+

### DIFF
--- a/src/ec_git_vsn.erl
+++ b/src/ec_git_vsn.erl
@@ -89,7 +89,7 @@ parse_tags(Pattern) ->
     Cmd = io_lib:format("git describe --abbrev=0 --match \"~s*\"", [Pattern]),
     Tag = os:cmd(Cmd),
     Vsn = slice(Tag, len(Pattern) + 1),
-    Vsn1 = trim(Vsn, left, $v),
+    Vsn1 = trim(Vsn, left, "v"),
     {Tag, Vsn1}.
 
 -ifdef(unicode_str).
@@ -98,6 +98,6 @@ trim(Str, Dir, Chars) -> string:trim(Str, Dir, Chars).
 slice(Str, Len) -> string:slice(Str, Len).
 -else.
 len(Str) -> string:len(Str).
-trim(Str, Dir, Chars) -> string:strip(Str, Dir, Chars).
+trim(Str, Dir, [Chars|_]) -> string:strip(Str, Dir, Chars).
 slice(Str, Len) -> string:substr(Str, Len).
 -endif.

--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -127,7 +127,7 @@ ask_convert(Prompt, TransFun, Type,  Default) ->
                                                            Default ->
                                                                [" (", io_lib:format("~p", [Default]) , ")"]
                                                        end, "> "])),
-    Data = trim(trim(io:get_line(NewPrompt)), both, $\n),
+    Data = trim(trim(io:get_line(NewPrompt)), both, [$\n]),
     Ret = TransFun(Data),
     case Ret of
         no_data ->
@@ -202,7 +202,7 @@ trim(Str) -> string:trim(Str).
 trim(Str, Dir, Chars) -> string:trim(Str, Dir, Chars).
 -else.
 trim(Str) -> string:strip(Str).
-trim(Str, Dir, Chars) -> string:strip(Str, Dir, Chars).
+trim(Str, Dir, [Chars|_]) -> string:strip(Str, Dir, Chars).
 -endif.
 
 %%%====================================================================


### PR DESCRIPTION
The trim/3 function accepts a list of graphemes rather than a single
character. This means previous patches were wrong and totally breaking.