### PR TITLE
Use environment variables to find the tmp directory

### DIFF
--- a/src/ec_file.erl
+++ b/src/ec_file.erl
@@ -277,9 +277,15 @@ remove_recursive(Path, Options) ->
 tmp() ->
     case erlang:system_info(system_architecture) of
         "win32" ->
-            "./tmp";
+            case os:getenv("TEMP") of
+                false -> "./tmp";
+                Val -> Val
+            end;
         _SysArch ->
-            "/tmp"
+            case os:getenv("TMPDIR") of
+                false -> "/tmp";
+                Val -> Val
+            end
     end.
 
 %% Copy the subfiles of the From directory to the to directory.


### PR DESCRIPTION
It's not very pretty to have a `tmp` directory appear out of nowhere on Windows, also on Unix systems, `$TMPDIR` is authoritative, there are systems that don't have a `/tmp` path (e.g. I had this problem just now on Android).