### PR TITLE
Avoid a warning on Erlang/OTP 24

### DIFF
--- a/src/ec_cmd_log.erl
+++ b/src/ec_cmd_log.erl
@@ -22,7 +22,7 @@
 %%% use this to talk to the users if you are wrting code for the system
 -module(ec_cmd_log).
 
-%% Avoids a warning on Erlang/OTP 24
+%% Avoid clashing with `error/3` BIF added in Erlang/OTP 24
 -compile({no_auto_import,[error/3]}).
 
 -export([new/1,

--- a/src/ec_cmd_log.erl
+++ b/src/ec_cmd_log.erl
@@ -22,6 +22,9 @@
 %%% use this to talk to the users if you are wrting code for the system
 -module(ec_cmd_log).
 
+%% Avoids a warning on Erlang/OTP 24
+-compile({no_auto_import,[error/3]}).
+
 -export([new/1,
          new/2,
          new/3,


### PR DESCRIPTION
to make sure Rebar 3 can bootstrap on that version with warnings-as-errors compiler settings.

Closes #145.