### PR TITLE
Remove -file attribute pointing to a non-existing file on ec_semver_parser

### DIFF
--- a/src/ec_semver_parser.erl
+++ b/src/ec_semver_parser.erl
@@ -48,7 +48,6 @@ parse(Input) when is_binary(Input) ->
 
 
 transform(_,Node,_Index) -> Node.
--file("peg_includes.hrl", 1).
 -type index() :: {{line, pos_integer()}, {column, pos_integer()}}.
 -type input() :: binary().
 -type parse_failure() :: {fail, term()}.


### PR DESCRIPTION
This PR tries to remove `-file` attribute pointing to a non-existent file which may cause an issue for systems that are not built on rebar.