### PR TITLE
Fixes for dialyzer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,20 +12,20 @@ jobs:
   build:
     name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    container:
+      image: erlang:${{matrix.otp_version}}
 
     strategy:
       matrix:
-        otp_version: ['23.2.1', '22.3.4.2', '21.3.8.16', '20.3.8.21', '19.3.6.13']
+        otp_version: ['23.2', '22.3', '21.3', '20.3', '19.3']
         os: [ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v2
 
-    - uses: bajankristof/setup-erlang@master
-      with:
-        otp-version: ${{ matrix.otp_version }}
-
     - name: Compile
       run: rebar3 compile
+    - name: Dialyze
+      run: rebar3 as test dialyzer
     - name: EUnit tests
       run: TERM=xterm rebar3 eunit

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ _build
 erl_crash.dump
 *.pyc
 *~
+TEST-*.xml
+/foo
 
 src/ec_semver_parser.peg

--- a/src/ec_git_vsn.erl
+++ b/src/ec_git_vsn.erl
@@ -97,8 +97,7 @@ parse_tags(Pattern) ->
 -ifdef(unicode_str).
 len(Str) -> string:length(Str).
 trim(Str, right, Chars) -> string:trim(Str, trailing, Chars);
-trim(Str, left, Chars) -> string:trim(Str, leading, Chars);
-trim(Str, both, Chars) -> string:trim(Str, both, Chars).
+trim(Str, left, Chars) -> string:trim(Str, leading, Chars).
 slice(Str, Len) -> string:slice(Str, Len).
 -else.
 len(Str) -> string:len(Str).

--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -199,8 +199,6 @@ get_string(String) ->
 
 -ifdef(unicode_str).
 trim(Str) -> string:trim(Str).
-trim(Str, right, Chars) -> string:trim(Str, trailing, Chars);
-trim(Str, left, Chars) -> string:trim(Str, leading, Chars);
 trim(Str, both, Chars) -> string:trim(Str, both, Chars).
 -else.
 trim(Str) -> string:strip(Str).


### PR DESCRIPTION
Regarding the dead code fixes, another option (instead of removing the dead code) is to expose the functions, after which the dialyzer doesn't know where to look for a consumer 😄 

- [ ] wait until erlef/setup-beam is available with `rebar3` then pull it here
- [x] accept @ferd's recommendation: https://github.com/erlware/erlware_commons/pull/152#discussion_r600472559

**Note**: I took the liberty of adding `dialyzer` to CI.