### PR TITLE
runmany_wrap/2 didn't call Fun: missing parens

### DIFF
--- a/src/ec_plists.erl
+++ b/src/ec_plists.erl
@@ -875,7 +875,7 @@ cluster_runmany(_, _, [_Non|_Empty], []=_Nodes, []=_Running, _) ->
 -ifdef(fun_stacktrace).
 runmany_wrap(Fun, Parent) ->
     try
-        Fun
+        Fun()
     catch
         exit:siblingdied ->
             ok;
@@ -889,7 +889,7 @@ runmany_wrap(Fun, Parent) ->
 -else.
 runmany_wrap(Fun, Parent) ->
     try
-        Fun
+        Fun()
     catch
         exit:siblingdied ->
             ok;


### PR DESCRIPTION
Spotted and solved by@markan. See https://github.com/erlware/erlware_commons/issues/138.
@ferd, could you have a look?