### PR TITLE
Removed other redudant clauses in local parse/3

### DIFF
--- a/src/ec_date.erl
+++ b/src/ec_date.erl
@@ -208,14 +208,6 @@ parse([Month,Day,Year,Hour | PAM], _Now, _Opts)
   when ?is_meridian(PAM) andalso ?is_hinted_month(Month) andalso ?is_day(Day) ->
     {{Year, Month, Day}, {hour(Hour, PAM), 0, 0}};
 
-%% Date/Times Dec 1st, 2012 18:25:15 (no AM/PM)
-parse([Month,Day,Year,Hour,$:,Min,$:,Sec], _Now, _Opts)
-  when ?is_hinted_month(Month) andalso ?is_day(Day) ->
-    {{Year, Month, Day}, {hour(Hour, []), Min, Sec}};
-parse([Month,Day,Year,Hour,$:,Min], _Now, _Opts)
-  when ?is_hinted_month(Month) andalso ?is_day(Day) ->
-    {{Year, Month, Day}, {hour(Hour, []), Min, 0}};
-
 %% Date/Times Fri Nov 21 14:55:26 +0000 2014 (Twitter format)
 parse([Month, Day, Hour,$:,Min,$:,Sec, Year], _Now, _Opts)
   when ?is_hinted_month(Month), ?is_day(Day), ?is_year(Year) ->


### PR DESCRIPTION
Same remark than https://github.com/erlware/erlware_commons/pull/162
@ferd, could have a look?
```
1> [Month,Day,Year,Hour,$:,Min,$:,Sec | PAM] = [8,28,2014,23,$:,39,$:,10].
[8,28,2014,23,58,39,58,10]
2> [Month,Day,Year,Hour,$:,Min | PAM] = [8,28,2014,23,$:,39].
[8,28,2014,23,58,39]
3> [Month,Day,Year,Hour | PAM] = [8,28,2014,23].
[8,28,2014,23]
4> PAM.
[]
```