### PR TITLE
Removed checks on deprecated crypto:sha/1 & random:uniform/0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,12 +9,9 @@
 
 %% Compiler Options ============================================================
 {erl_opts,
- [{platform_define, "^[0-9]+", namespaced_types},
-  {platform_define, "^[0-9]+", have_callback_support},
-  {platform_define, "^R1[4|5]", deprecated_crypto},
-  {platform_define, "^1[8|9]", rand_module},
-  {platform_define, "^2", rand_module},
-  {platform_define, "^2", unicode_str},
+ [{platform_define, "^[0-9]+",   namespaced_types},
+  {platform_define, "^[0-9]+",   have_callback_support},
+  {platform_define, "^2",        unicode_str},
   {platform_define, "^(R|1|20)", fun_stacktrace},
   debug_info,
   warnings_as_errors]}.

--- a/src/ec_file.erl
+++ b/src/ec_file.erl
@@ -143,19 +143,13 @@ try_write_group(To, #file_info{gid=OwnerId}) ->
 %%      named after the UNIX utility.
 -spec md5sum(string() | binary()) -> string().
 md5sum(Value) ->
-    bin_to_hex(erlang:md5(Value)).
+    bin_to_hex(crypto:hash(md5, Value)).
 
 %% @doc return the SHA-1 digest of a string or a binary,
 %%      named after the UNIX utility.
--ifdef(deprecated_crypto).
--spec sha1sum(string() | binary()) -> string().
-sha1sum(Value) ->
-    bin_to_hex(crypto:sha(Value)).
--else.
 -spec sha1sum(string() | binary()) -> string().
 sha1sum(Value) ->
     bin_to_hex(crypto:hash(sha, Value)).
--endif.
 
 bin_to_hex(Bin) ->
     hex(binary_to_list(Bin)).

--- a/src/ec_file.erl
+++ b/src/ec_file.erl
@@ -376,14 +376,8 @@ sub_files(From) ->
     {ok, SubFiles} = file:list_dir(From),
     [filename:join(From, SubFile) || SubFile <- SubFiles].
 
--ifdef(rand_module).
 random_uniform() ->
     rand:uniform().
--else.
-random_uniform() ->
-    random:seed(os:timestamp()),
-    random:uniform().
--endif.
 
 %%%===================================================================
 %%% Test Functions


### PR DESCRIPTION
- CI/CD lowest version is 19.3
- from 19.3, [`rand`](https://www.erlang.org/docs/19/man/rand)  module exists
- from 19.3, [`crypto:hash/1`](https://www.erlang.org/docs/19/man/crypto#hash-2) exists.