### PR TITLE
Removed have_callback_support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,6 @@
 %% Compiler Options ============================================================
 {erl_opts,
  [{platform_define, "^[0-9]+",   namespaced_types},
-  {platform_define, "^[0-9]+",   have_callback_support},
   {platform_define, "^2",        unicode_str},
   {platform_define, "^(R|1|20)", fun_stacktrace},
   debug_info,

--- a/src/ec_dictionary.erl
+++ b/src/ec_dictionary.erl
@@ -42,8 +42,6 @@
 -type key(T) :: T.
 -type value(T) :: T.
 
--ifdef(have_callback_support).
-
 -callback new() -> any().
 -callback has_key(key(any()), any()) -> boolean().
 -callback get(key(any()), any()) -> any().
@@ -54,27 +52,6 @@
 -callback to_list(any()) -> [{key(any()), value(any())}].
 -callback from_list([{key(any()), value(any())}]) -> any().
 -callback keys(any()) -> [key(any())].
-
--else.
-
-%% In the case where R14 or lower is being used to compile the system
-%% we need to export a behaviour info
--export([behaviour_info/1]).
--spec behaviour_info(atom()) -> [{atom(), arity()}] | undefined.
-behaviour_info(callbacks) ->
-    [{new, 0},
-     {has_key, 2},
-     {get, 2},
-     {add, 3},
-     {remove, 2},
-     {has_value, 2},
-     {size, 1},
-     {to_list, 1},
-     {from_list, 1},
-     {keys, 1}];
-behaviour_info(_Other) ->
-    undefined.
--endif.
 
 %%%===================================================================
 %%% API

--- a/src/ec_vsn.erl
+++ b/src/ec_vsn.erl
@@ -27,23 +27,8 @@
 %% however you should not rely on the internal representation here
 -type t() :: #t{}.
 
--ifdef(have_callback_support).
-
 -callback new() -> any().
 -callback vsn(any()) -> {ok, string()} | {error, Reason::any()}.
-
--else.
-
-%% In the case where R14 or lower is being used to compile the system
-%% we need to export a behaviour info
--export([behaviour_info/1]).
--spec behaviour_info(atom()) -> [{atom(), arity()}] | undefined.
-behaviour_info(callbacks) ->
-    [{new, 0},
-     {vsn, 1}];
-behaviour_info(_Other) ->
-    undefined.
--endif.
 
 %%%===================================================================
 %%% API


### PR DESCRIPTION
* introduced by 95f723e1e043eaa948807c9e5572d9f948ad3585
* mentioned as well in 47bcbd49b6fdef020cf190c20a13856dd86c0577
* introduced for compatibility with OTP R14
* CI/CD now tests from R19 and onwards.