### PR TITLE
Removed namespaced_types

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,8 +9,7 @@
 
 %% Compiler Options ============================================================
 {erl_opts,
- [{platform_define, "^[0-9]+",   namespaced_types},
-  {platform_define, "^2",        unicode_str},
+ [{platform_define, "^2",        unicode_str},
   {platform_define, "^(R|1|20)", fun_stacktrace},
   debug_info,
   warnings_as_errors]}.

--- a/src/ec_dict.erl
+++ b/src/ec_dict.erl
@@ -34,11 +34,7 @@
 %%%===================================================================
 %% This should be opaque, but that kills dialyzer so for now we export it
 %% however you should not rely on the internal representation here
--ifdef(namespaced_types).
 -type dictionary(_K, _V) :: dict:dict().
--else.
--type dictionary(_K, _V) :: dict().
--endif.
 
 %%%===================================================================
 %%% API

--- a/src/ec_plists.erl
+++ b/src/ec_plists.erl
@@ -480,16 +480,9 @@ usort(Fun, List, Malt) ->
     runmany(Fun2, {recursive, Fuse}, List, Malt).
 
 %% @doc Like below, assumes default MapMalt of 1.
--ifdef(namespaced_types).
 -spec mapreduce(MapFunc, list()) -> dict:dict() when
       MapFunc ::  fun((term()) -> DeepListOfKeyValuePairs),
       DeepListOfKeyValuePairs :: [DeepListOfKeyValuePairs] | {Key::term(), Value::term()}.
--else.
--spec mapreduce(MapFunc, list()) -> dict() when
-      MapFunc ::  fun((term()) -> DeepListOfKeyValuePairs),
-      DeepListOfKeyValuePairs :: [DeepListOfKeyValuePairs] | {Key::term(), Value::term()}.
--endif.
-
 
 mapreduce(MapFunc, List) ->
     mapreduce(MapFunc, List, 1).
@@ -518,17 +511,10 @@ mapreduce(MapFunc, List, MapMalt) ->
 %%
 %% mapreduce requires OTP R11B, or it may leave monitoring messages in the
 %% message queue.
--ifdef(namespaced_types).
 -spec mapreduce(MapFunc, list(), InitState::term(), ReduceFunc, malt()) -> dict:dict() when
       MapFunc :: fun((term()) -> DeepListOfKeyValuePairs),
       DeepListOfKeyValuePairs :: [DeepListOfKeyValuePairs] | {Key::term(), Value::term()},
       ReduceFunc :: fun((OldState::term(), Key::term(), Value::term()) -> NewState::term()).
--else.
--spec mapreduce(MapFunc, list(), InitState::term(), ReduceFunc, malt()) -> dict() when
-      MapFunc :: fun((term()) -> DeepListOfKeyValuePairs),
-      DeepListOfKeyValuePairs :: [DeepListOfKeyValuePairs] | {Key::term(), Value::term()},
-      ReduceFunc :: fun((OldState::term(), Key::term(), Value::term()) -> NewState::term()).
--endif.
 mapreduce(MapFunc, List, InitState, ReduceFunc, MapMalt) ->
     Parent = self(),
     {Reducer, ReducerRef} =


### PR DESCRIPTION
* introduced for handling deprecated types existing before R17
* introduced in 523a66ad7448cf4b49c6b803f1198e5b3e2c7960
* CI/CD handles R19 up to R24
* [R19](https://www.erlang.org/docs/19/man/dict) and [R24](https://www.erlang.org/docs/24/man/dict#type-dict) `dict:dict/0`.