### PR TITLE
Bumped OTP versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['24.0', '23.3', '22.3', '21.3', '20.3', '19.3']
+        otp_version: ['25.3', '25.2', '23.2']
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
* aligned OTP versions with [Debian](https://packages.debian.org/search?keywords=erlang)
* keeps versions from bullseye (old stable) to sid (unstable).

```shell
$ curl --silent https://packages.debian.org/search?keywords=erlang | \
  sed -ne '/Package erlang</,/<\/ul>/{/<\/a>/p; /br/p}' | \
  sed -e 's/<a.*$//' | \
  perl -0777 -pE 's/<li class="(\w+)">\n/$1/g; s/<br>([^\s]+)/$1/g; s/\+.*(?=\n)//g' | \
  sed -e '1i name otp-version' | \
  column -t
name          otp-version
buster        1:22.2.7
bullseye      1:23.2.6
bookworm      1:25.2.3
trixie        1:25.3.2.8
sid           1:25.3.2.8
experimental  1:26.2.1

$ curl -I  https://packages.debian.org/search?keywords=erlang
HTTP/2 200
date: Tue, 20 Feb 2024 22:21:53 GMT
server: Apache
last-modified: Tue, 20 Feb 2024 21:50:40 GMT
vary: Accept-Encoding,negotiate,accept-language
x-clacks-overhead: GNU Terry Pratchett
expires: Wed, 21 Feb 2024 09:04:02 +0000
x-content-type-options: nosniff
x-frame-options: sameorigin
referrer-policy: no-referrer
x-xss-protection: 1
permissions-policy: interest-cohort=()
strict-transport-security: max-age=15552000
age: 1873
content-length: 184625
content-type: text/html; charset=UTF-8
```