### PR TITLE
Removed unicode_str & fun_stacktrace

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,11 +8,7 @@
 {erl_first_files, ["ec_dictionary", "ec_vsn"]}.
 
 %% Compiler Options ============================================================
-{erl_opts,
- [{platform_define, "^2",        unicode_str},
-  {platform_define, "^(R|1|20)", fun_stacktrace},
-  debug_info,
-  warnings_as_errors]}.
+{erl_opts, [debug_info, warnings_as_errors]}.
 
 %% EUnit =======================================================================
 {eunit_opts, [verbose,

--- a/src/ec_date.erl
+++ b/src/ec_date.erl
@@ -101,7 +101,7 @@ parse(Date, Now) ->
     do_parse(Date, Now, []).
 
 do_parse(Date, Now, Opts) ->
-    case filter_hints(parse(tokenise(uppercase(Date), []), Now, Opts)) of
+    case filter_hints(parse(tokenise(string:uppercase(Date), []), Now, Opts)) of
         {error, bad_date} ->
             erlang:throw({?MODULE, {bad_date, Date}});
         {D1, T1} = {{Y, M, D}, {H, M1, S}}
@@ -708,12 +708,6 @@ pad6(X) when is_integer(X) ->
 
 ltoi(X) ->
     list_to_integer(X).
-
--ifdef(unicode_str).
-uppercase(Str) -> string:uppercase(Str).
--else.
-uppercase(Str) -> string:to_upper(Str).
--endif.
 
 %%%===================================================================
 %%% Tests

--- a/src/ec_git_vsn.erl
+++ b/src/ec_git_vsn.erl
@@ -94,21 +94,10 @@ parse_tags(Pattern) ->
         "fatal: " ++ _ ->
             {undefined, ""};
         _ ->
-            Vsn = slice(Tag, len(Pattern)),
-            Vsn1 = trim(trim(Vsn, left, "v"), right, "\n"),
+            Vsn  = string:slice(Tag, string:length(Pattern)),
+            Vsn1 = string:trim(string:trim(Vsn, leading, "v"), trailing, "\n"),
             {Tag, Vsn1}
     end.
-
--ifdef(unicode_str).
-len(Str) -> string:length(Str).
-trim(Str, right, Chars) -> string:trim(Str, trailing, Chars);
-trim(Str, left, Chars) -> string:trim(Str, leading, Chars).
-slice(Str, Len) -> string:slice(Str, Len).
--else.
-len(Str) -> string:len(Str).
-trim(Str, Dir, [Chars|_]) -> string:strip(Str, Dir, Chars).
-slice(Str, Len) -> string:substr(Str, Len + 1).
--endif.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/src/ec_plists.erl
+++ b/src/ec_plists.erl
@@ -858,21 +858,6 @@ cluster_runmany(_, _, [_Non|_Empty], []=_Nodes, []=_Running, _) ->
 %% We have data, but no nodes either available or occupied
     erlang:exit(allnodescrashed).
 
--ifdef(fun_stacktrace).
-runmany_wrap(Fun, Parent) ->
-    try
-        Fun()
-    catch
-        exit:siblingdied ->
-            ok;
-        exit:Reason ->
-            Parent ! {erlang:self(), error, Reason};
-        error:R ->
-            Parent ! {erlang:self(), error, {R, erlang:get_stacktrace()}};
-        throw:R ->
-            Parent ! {erlang:self(), error, {{nocatch, R}, erlang:get_stacktrace()}}
-    end.
--else.
 runmany_wrap(Fun, Parent) ->
     try
         Fun()
@@ -886,7 +871,6 @@ runmany_wrap(Fun, Parent) ->
         throw:R:Stacktrace ->
             Parent ! {erlang:self(), error, {{nocatch, R}, Stacktrace}}
     end.
--endif.
 
 delete_running(Pid, [{Pid, Node, List}|Running], Acc) ->
     {Running ++ Acc, Node, List};

--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -127,7 +127,7 @@ ask_convert(Prompt, TransFun, Type,  Default) ->
                                                            Default ->
                                                                [" (", io_lib:format("~p", [Default]) , ")"]
                                                        end, "> "])),
-    Data = trim(trim(io:get_line(NewPrompt)), both, [$\n]),
+    Data = string:trim(string:trim(io:get_line(NewPrompt)), both, [$\n]),
     Ret = TransFun(Data),
     case Ret of
         no_data ->
@@ -196,14 +196,6 @@ get_string(String) ->
         false ->
             no_clue
     end.
-
--ifdef(unicode_str).
-trim(Str) -> string:trim(Str).
-trim(Str, both, Chars) -> string:trim(Str, both, Chars).
--else.
-trim(Str) -> string:strip(Str).
-trim(Str, Dir, [Chars|_]) -> string:strip(Str, Dir, Chars).
--endif.
 
 %%%====================================================================
 %%% tests


### PR DESCRIPTION
- CI/CD uses R23 and onwards
- `unicode_str` (introduced in f8f72b7cc5946131743f47454ee87494806deed8) to work around R20 compile warnings
- `fun_stacktrace` (introduced in ad2d57d8b62b86ec1f3d03441f7defa595f2c59c) relies on `erlang:get_stacktrace/0`, [deprecated from R23](https://www.erlang.org/doc/general_info/removed#functions-removed-in-otp-23).