### PR TITLE
OTP bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['25.3', '25.2', '23.2']
+        otp_version: ['26.2', '25.3', '25.2', '23.2']
         os: [ubuntu-latest]
 
     steps:

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,8 +10,15 @@ Rebar2Deps = [
               {cf, ".*", {git, "https://github.com/project-fifo/cf", {tag, "0.2.2"}}}
              ],
 
+NoDialWarns  = {dialyzer, [{warnings, [no_unknown]}]},
+OTPRelease   = erlang:list_to_integer(erlang:system_info(otp_release)),
+WarnsRemoved = case OTPRelease<26 of
+		   true  -> fun(Config) -> Config end;
+		   false -> fun(Config) -> lists:keystore(dialyzer, 1, Config, NoDialWarns) end
+	       end,
+
 case IsRebar3 of
-    true -> CONFIG;
+    true -> WarnsRemoved(CONFIG);
     false ->
-        lists:keyreplace(deps, 1, CONFIG, {deps, Rebar2Deps})
+        lists:keyreplace(deps, 1, WarnsRemoved(CONFIG), {deps, Rebar2Deps})
 end.


### PR DESCRIPTION
* sequel of 17e6f890783c18381fc39ad48779b3d09e7f0ffb
* added R26 in CI/CD, and cleared out dialyzer warnings
* from R26, by default, [`-Wno_unknown` suppresses warnings](https://www.erlang.org/doc/man/dialyzer.html#warning_options)
* in R25, it was the reverse behavior: [`-Wunknown` allows warnings](https://www.erlang.org/docs/25/man/dialyzer#format_warning-1).