### PR TITLE
GitHub action renaming & OTP bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: ['26.2', '25.3', '25.2', '23.2']
+        otp_version: ['27.0', '25.3', '25.2', '23.2']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: EUnit
+name: Integration tests
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    name: OTP ${{ matrix.otp_version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     container:
       image: erlang:${{matrix.otp_version}}
@@ -25,7 +25,7 @@ jobs:
 
     - name: Compile
       run: rebar3 compile
-    - name: Dialyze
+    - name: Dialyzer
       run: rebar3 as test dialyzer
-    - name: EUnit tests
+    - name: EUnit
       run: TERM=xterm rebar3 eunit


### PR DESCRIPTION
Aligned OTP versions with Debian:
```shell
    $ curl --silent https://packages.debian.org/search?keywords=erlang | \
        sed -ne '/Package erlang</,/<\/ul>/{/<\/a>/p; /br/p}' | \
        sed -e 's/<a.*$//' | \
        perl -0777 -pE 's/<li class="(\w+)">\n/$1/g; s/<br>([^\s]+)/$1/g; s/\+.*(?=\n)//g' | \
        sed -e '1i name otp-version' | \
        column -t
    
    name          otp-version
    buster        1:22.2.7
    bullseye      1:23.2.6
    bookworm      1:25.2.3
    trixie        1:25.3.2.12
    sid           1:25.3.2.12
    experimental  1:27.0
    ```