### PR TITLE
Replaced random_uniform/1 by rand:uniform/1

### DIFF
--- a/src/ec_file.erl
+++ b/src/ec_file.erl
@@ -223,7 +223,7 @@ real_dir_path(Path) ->
 %% function of the same name.
 -spec insecure_mkdtemp() -> TmpDirPath::file:name() | {error, term()}.
 insecure_mkdtemp() ->
-    UniqueNumber = erlang:integer_to_list(erlang:trunc(random_uniform() * 1000000000000)),
+    UniqueNumber = erlang:integer_to_list(erlang:trunc(rand:uniform() * 1_000_000_000_000)),
     TmpDirPath =
         filename:join([tmp(), lists:flatten([".tmp_dir", UniqueNumber])]),
 
@@ -375,9 +375,6 @@ hex0(I)  -> $0 + I.
 sub_files(From) ->
     {ok, SubFiles} = file:list_dir(From),
     [filename:join(From, SubFile) || SubFile <- SubFiles].
-
-random_uniform() ->
-    rand:uniform().
 
 %%%===================================================================
 %%% Test Functions


### PR DESCRIPTION
* leftover of 5118421f6ff1b358a3b76b7dfb02b81645386e31
* code base contains only one occurence of `random_uniform/1`

```shell
# git grep random_uniform
src/ec_file.erl:    UniqueNumber = erlang:integer_to_list(erlang:trunc(random_uniform() * 1000000000000)),
src/ec_file.erl:random_uniform() ->
```