### PR TITLE
Fix issue on windows with Erlang/OTP 28 which causes temporary directories to get created at the wrong path.

### DIFF
--- a/src/ec_file.erl
+++ b/src/ec_file.erl
@@ -324,13 +324,13 @@ remove_recursive(Path, Options) ->
 
 -spec tmp() -> file:name().
 tmp() ->
-    case erlang:system_info(system_architecture) of
-        "win32" ->
+    case os:type() of
+        {win32, _} ->
             case os:getenv("TEMP") of
                 false -> "./tmp";
                 Val -> Val
             end;
-        _SysArch ->
+        _ ->
             case os:getenv("TMPDIR") of
                 false -> "/tmp";
                 Val -> Val


### PR DESCRIPTION
In ec_file:tmp/0, a call to erlang:system_info(system_architecture) is used in order to determine the location to create temporary directories for each operating system. In OTP28, the result of the call is not the expected "win32" string, but the target triplet (i.e. "x86_64-pc-windows"). As a result, temporary directories are created at the wrong location, which causes unexpected behavior in downstream packages.

The fix uses os:type/0 to detect whether we are currently running on windows which has a more stable result.