### PR TITLE
ci: use full commit hashes

### DIFF
--- a/.github/workflows/otp-bump.yml
+++ b/.github/workflows/otp-bump.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@11bd719 # v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69 # v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.12
     - name: Setup dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: Pull OTP versions from Debian
       run: python3 bump-otp-matrix.py
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@271a8d0 # v7.0.8
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
       with:
         token: ${{ secrets.OTP_BUMP }}
         delete-branch: true


### PR DESCRIPTION
GitHub actions failed because [short commit hashes were used](https://github.com/erlware/erlware_commons/actions/runs/17365024064/job/49290459757).

Instead, use the full commit hashes.