### PR TITLE
Fix warning for to bare `catch` in OTP29

### DIFF
--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -182,11 +182,8 @@ get_boolean(_) ->
 get_integer([]) ->
     no_data;
 get_integer(String) ->
-    case (catch list_to_integer(String)) of
-        {'Exit', _} ->
-            no_clue;
-        Integer ->
-            Integer
+    try list_to_integer(String))
+    catch _:_ -> no_clue
     end.
 
 %% @doc Solely returns a string give the string. This is so the same


### PR DESCRIPTION
Hi! With OTP29 generating a warning for bare `catch` statements, this fixes that.

I noticed the tests weren't passing, but I haven't dug into it to solve that, since it seems more systemic.

Anyway, thanks!