### PR TITLE
Fix syntax error in get_integer

### DIFF
--- a/src/ec_talk.erl
+++ b/src/ec_talk.erl
@@ -182,7 +182,7 @@ get_boolean(_) ->
 get_integer([]) ->
     no_data;
 get_integer(String) ->
-    try list_to_integer(String))
+    try list_to_integer(String)
     catch _:_ -> no_clue
     end.
 


### PR DESCRIPTION
Syntax error during compilation

<img width="1280" height="488" alt="image" src="https://github.com/user-attachments/assets/673b5f16-4c89-4f3d-acd4-11573205e0bd" />
